### PR TITLE
change AnsibleUnsafeText to int

### DIFF
--- a/tasks/check_and_upload_image.yml
+++ b/tasks/check_and_upload_image.yml
@@ -55,7 +55,7 @@
     - upgrade_required
     - "new_image not in dir_output.stdout[0]"
     - '"local_new_image.stat.size" not in "dir_output.stdout[0]"'
-    - local_new_image.stat.size > device_storage.available
+    - local_new_image.stat.size > device_storage.available|int
 
 - name: upload > Debug output for space
   debug:
@@ -84,7 +84,7 @@
   when:
     - UpgradeType == 'cat-software-install'
     - upgrade_required
-    - (local_new_image.stat.size * 2) > device_storage.available
+    - (local_new_image.stat.size * 2) > device_storage.available|int
     - "new_image not in dir_output.stdout[0]"
     - '"local_new_image.stat.size" not in "dir_output.stdout[0]"'
 

--- a/tasks/check_and_upload_image.yml
+++ b/tasks/check_and_upload_image.yml
@@ -20,7 +20,7 @@
     src: "{{ ansible_net_image }}"
     dest: "{{ ImagePath }}"
   when:
-    - BackupImage
+    - BackupImage|bool
     - local_bin_image is failed
     - UpgradeType == 'ios-bin-upgrade'
 
@@ -52,7 +52,7 @@
         answer: 'y'
   when:
     - UpgradeType == 'ios-bin-upgrade'
-    - upgrade_required
+    - upgrade_required|bool
     - "new_image not in dir_output.stdout[0]"
     - '"local_new_image.stat.size" not in "dir_output.stdout[0]"'
     - local_new_image.stat.size > device_storage.available|int
@@ -61,7 +61,7 @@
   debug:
     msg: "Local image size {{ local_new_image.stat.size }}  doubled {{ local_new_image.stat.size * 2 }} > {{ device_storage.available }}"
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - UpgradeType == 'cat-software-install'
 
 - name: "Display directory listing output"
@@ -83,7 +83,7 @@
         answer: 'y'
   when:
     - UpgradeType == 'cat-software-install'
-    - upgrade_required
+    - upgrade_required|bool
     - (local_new_image.stat.size * 2) > device_storage.available|int
     - "new_image not in dir_output.stdout[0]"
     - '"local_new_image.stat.size" not in "dir_output.stdout[0]"'
@@ -94,7 +94,7 @@
     src: "{{ ImagePath }}/{{ new_image }}"
     dest: "flash:{{ new_image }}"
   when:
-  # - upgrade_required # TODO: Or if boot is set to new_image, but, new_image is not present in dir_output.stdout[0]
+  # - upgrade_required|bool # TODO: Or if boot is set to new_image, but, new_image is not present in dir_output.stdout[0]
     - "new_image not in dir_output.stdout[0]"
 
 
@@ -106,32 +106,32 @@
      - result[0] contains {{ local_new_image.stat.checksum }}
   register: switch_image_verify
   when:
-    - upgrade_required
+    - upgrade_required|bool
 
 - name: upload > Switch returned md5sum
   debug:
     var: switch_image_verify.stdout
   when:
-    - upgrade_required
+    - upgrade_required|bool
 
 - name: check > parse the raw output from 'dir flash' output
   command_parser:
     file: "{{ role_path }}/tasks/parsers/ios/verify.yml"
     content: "{{ switch_image_verify.stdout[0] }}"
   when:
-    - upgrade_required
+    - upgrade_required|bool
 
 
 - name: check > debug > contents of current_switch_image
   debug:
     var: current_switch_image
   when:
-    - upgrade_required
+    - upgrade_required|bool
 
 
 - name: upload > Fail when uploaded image md5 does not match local md5
   fail:
     msg: "Uploaded image {{ new_image }} md5 did not match.  Perhaps issue in upload. {{ current_switch_image.md5 }} is not {{ local_new_image.stat.checksum }}"
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - local_new_image.stat.checksum != current_switch_image.md5

--- a/tasks/installers/install_cat_software_install.yml
+++ b/tasks/installers/install_cat_software_install.yml
@@ -6,7 +6,7 @@
     commands:
       - software install file flash:{{ new_image }} new force on-reboot
   register: cat_install_output
-  when: upgrade_required
+  when: upgrade_required|bool
 
 - name: reboot > Debug output from install command
   debug:
@@ -15,10 +15,10 @@
 - name: reboot > Save the running configuration to startup
   ios_config:
     save_when: always
-  when: upgrade_required
+  when: upgrade_required|bool
 
 - name: reboot > REBOOT ROUTER
   ios_command:
     commands:
       - "reload\n"
-  when: upgrade_required or reboot_required
+  when: upgrade_required|bool or reboot_required|bool

--- a/tasks/installers/install_ios_config_boot_and_reboot.yml
+++ b/tasks/installers/install_ios_config_boot_and_reboot.yml
@@ -2,17 +2,17 @@
 - name: reboot > About to update boot
   debug:
     msg: "Updating boot image to flash:{{ new_image }}"
-  when: upgrade_required
+  when: upgrade_required|bool
 
 - name: reboot > Update boot image
   ios_config:
     lines:
       - boot system flash:{{ new_image }}
     save_when: changed
-  when: upgrade_required
+  when: upgrade_required|bool
 
 - name: reboot > REBOOT ROUTER
   ios_command:
     commands:
       - "reload\n"
-  when: upgrade_required
+  when: upgrade_required|bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,7 +68,7 @@
 # Configure boot image configuration setting and reboot for IOS devices
 - import_tasks: installers/install_ios_config_boot_and_reboot.yml
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - UpgradeType == 'ios-bin-upgrade'
     - State == 'upgrade'
   become: true
@@ -76,7 +76,7 @@
 # Run the installer for a cat 'install' method
 - import_tasks: installers/install_cat_software_install.yml
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - UpgradeType == 'cat-software-install'
     - State == 'upgrade'
   become: true
@@ -84,5 +84,5 @@
 # Wait for device to become active again after reboot and report results
 - import_tasks: post_upgrade_checks.yml
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - State == 'upgrade'

--- a/tasks/post_upgrade_checks.yml
+++ b/tasks/post_upgrade_checks.yml
@@ -10,13 +10,13 @@
   connection: local
   ignore_errors: yes
   register: reboot_timer
-  when: upgrade_required
+  when: upgrade_required|bool
 
 - name: reboot > Wait for connection again if previous wait_for failed
   pause:
     seconds: 60
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - reboot_timer is failed
     - UpgradeType == 'cat-software-install'
 
@@ -31,7 +31,7 @@
     state: started
   connection: local
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - reboot_timer is failed
     - UpgradeType == 'cat-software-install'
 
@@ -42,7 +42,7 @@
       - 'more flash:packages.conf'
   register: pkg_conf_output
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - UpgradeType == 'cat-software-install'
 
 - name: reboot > cat-software-install > Parse package.conf output to get build number
@@ -50,7 +50,7 @@
     file: "{{ role_path }}/tasks/parsers/ios/more_packages_conf.yml"
     content: "{{ pkg_conf_output.stdout[0] }}"
   when:
-    - upgrade_required
+    - upgrade_required|bool
     - UpgradeType == 'cat-software-install'
 
 


### PR DESCRIPTION
Resolves the error: '>' not supported between instances of 'int' and 'AnsibleUnsafeText' in Ansible Tower 3.6.0 with Ansible 2.8.0
Cross-check done if it still works with ansible 2.8.5 on OS X